### PR TITLE
Generalize `ValidateExecutable` to pass if file is executable by any

### DIFF
--- a/input/input.go
+++ b/input/input.go
@@ -133,7 +133,7 @@ func (inp *Input) ValidateExecutable() error {
 		return err
 	}
 	mode := info.Mode()
-	if mode&0111 != 0 && mode&0011 != 0 {
+	if mode&0111 != 0 {
 		return nil
 	}
 	return errors.New("executable not executable")

--- a/input/input_test.go
+++ b/input/input_test.go
@@ -536,6 +536,21 @@ func TestInput_ValidateExecutable(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to write executable: %s", err)
 	}
+	userExecHaddockF := filepath.Join(haddockDir, "/userExec-haddock.sh")
+	err = os.WriteFile(userExecHaddockF, []byte("#!/bin/bash"), 0744)
+	if err != nil {
+		t.Errorf("Failed to write executable: %s", err)
+	}
+	groupExecHaddockF := filepath.Join(haddockDir, "/groupExec-haddock.sh")
+	err = os.WriteFile(groupExecHaddockF, []byte("#!/bin/bash"), 0654)
+	if err != nil {
+		t.Errorf("Failed to write executable: %s", err)
+	}
+	publicExecHaddockF := filepath.Join(haddockDir, "/publicExec-haddock.sh")
+	err = os.WriteFile(publicExecHaddockF, []byte("#!/bin/bash"), 0645)
+	if err != nil {
+		t.Errorf("Failed to write executable: %s", err)
+	}
 	nonExistHaddockF := filepath.Join(haddockDir, "/does-not-exist.sh")
 
 	type fields struct {
@@ -591,6 +606,33 @@ func TestInput_ValidateExecutable(t *testing.T) {
 				},
 			},
 			wantErr: true,
+		},
+		{
+			name: "user-executable",
+			fields: fields{
+				General: GeneralStruct{
+					HaddockExecutable: userExecHaddockF,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "group-executable",
+			fields: fields{
+				General: GeneralStruct{
+					HaddockExecutable: groupExecHaddockF,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "public-executable",
+			fields: fields{
+				General: GeneralStruct{
+					HaddockExecutable: publicExecHaddockF,
+				},
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/golang/glog"
 )
 
-const version = "v1.5.0"
+const version = "v1.5.1"
 
 func init() {
 	var versionPrint bool


### PR DESCRIPTION
This PR changes `ValidateExecutable` so that it will validate the executable if executable either by owner, group or public.