### PR TITLE
Generalize `.tbl` regex matching in `LoadDataset`

### DIFF
--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -437,8 +437,8 @@ func LoadDataset(projectDir string, pdbList string, rsuf string, lsuf string) ([
 		line := s.Text()
 		for k, v := range m {
 			// Handle the restraints
-			tblRegex := regexp.MustCompile(`(` + k + `)\w+\.tbl`)
-			tblMatch := tblRegex.FindStringSubmatch(line)
+			tblRegex := regexp.MustCompile(`(` + k + `).*tbl`)
+			tblMatch := tblRegex.FindStringSubmatch(filepath.Base(line))
 			if len(tblMatch) != 0 {
 				v.Restraints = append(v.Restraints, s.Text())
 			}

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -151,6 +151,7 @@ func TestLoadDataset(t *testing.T) {
 				"some/path/structure4_l_u_0.pdb\n"+
 				"some/path/structure4_l_u_1.pdb\n"+
 				"some/path/structure4_ambig.tbl\n"+
+				"some/path/structure4_unambig-rest.tbl\n"+
 				"some/path/structure4_ATP.top\n"+
 				"some/path/structure4_ATP.param\n"), 0644)
 	defer os.Remove("pdb.list")
@@ -171,7 +172,7 @@ func TestLoadDataset(t *testing.T) {
 			if len(v.Ligand) != 2 {
 				t.Errorf("Failed: Not all ligands were loaded")
 			}
-			if len(v.Restraints) != 1 {
+			if len(v.Restraints) != 2 {
 				t.Errorf("Failed: Not all restraints were loaded")
 			}
 			if len(v.Toppar) != 2 {


### PR DESCRIPTION
This PR changes the `LoadDataset` function so that it will capture the `.tbl` suffix regardless of the filename.