### PR TITLE
Identify the run state

### DIFF
--- a/main.go
+++ b/main.go
@@ -195,7 +195,10 @@ func main() {
 		// glog.Info("> Running " + job.ID + " (" + fmt.Sprint(i+1) + "/" + fmt.Sprint(total) + ")")
 		go func(job runner.Job, counter int) {
 
-			job.GetStatus(haddockVersion)
+			err := job.GetStatus(haddockVersion)
+			if err != nil {
+				glog.Exit("Failed to get job status: " + err.Error())
+			}
 
 			switch {
 			case job.Status == status.DONE:
@@ -217,7 +220,10 @@ func main() {
 					glog.Exit("Failed to run HADDOCK: " + runErr.Error())
 				}
 
-				job.GetStatus(haddockVersion)
+				err := job.GetStatus(haddockVersion)
+				if err != nil {
+					glog.Exit("Failed to get job status: " + err.Error())
+				}
 				elapsed := time.Since(now)
 				glog.Info(job.ID + " - " + job.Status + " in " + fmt.Sprintf("%.2f", elapsed.Seconds()) + " seconds")
 			}

--- a/runner/jobs.go
+++ b/runner/jobs.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"haddockrunner/input"
+	"haddockrunner/runner/status"
 	"haddockrunner/utils"
 	"haddockrunner/wrapper/haddock2"
 )
@@ -18,6 +19,7 @@ type Job struct {
 	Params     map[string]interface{}
 	Restraints input.Airs
 	Toppar     input.TopologyParams
+	Status     status.Status
 }
 
 // SetupHaddock24 sets up the HADDOCK job
@@ -137,5 +139,36 @@ func (j Job) RunHaddock3(cmd string) (string, error) {
 	}
 
 	return logF, nil
+
+}
+
+// StatusHaddock24 sets the status of the HADDOCK job
+func (j *Job) StatusHaddock24() {
+
+	haddockOut := filepath.Join(j.Path, "run1", "haddock.out")
+
+	found, err := utils.SearchInLog(haddockOut, "Finishing HADDOCK on:")
+	if err != nil || !found {
+		// There was either some error reading the log file, or
+		//  the key terminator was not found so we assume the job is incomplete
+		j.Status.Incomplete = true
+	} else {
+		j.Status.Finished = true
+	}
+
+}
+
+// StatusHaddock3 sets the status of the HADDOCK job
+func (j *Job) StatusHaddock3() {
+	haddockOut := filepath.Join(j.Path, "run1", "log")
+
+	found, err := utils.SearchInLog(haddockOut, "An error has occurred")
+	if err != nil || !found {
+		// There was either some error reading the log file, or
+		//  the key terminator was not found so we assume the job is incomplete
+		j.Status.Incomplete = true
+	} else {
+		j.Status.Finished = true
+	}
 
 }

--- a/runner/jobs.go
+++ b/runner/jobs.go
@@ -10,8 +10,6 @@ import (
 	"haddockrunner/runner/status"
 	"haddockrunner/utils"
 	"haddockrunner/wrapper/haddock2"
-
-	"github.com/golang/glog"
 )
 
 // Job is the HADDOCK job
@@ -156,11 +154,11 @@ func (j Job) Run(version int, cmd string) (string, error) {
 			err := errors.New("Failed to setup HADDOCK: " + errSetup2.Error())
 			return logF, err
 		}
-		logF, err = j.RunHaddock24(cmd)
-		if err != nil {
-			err := errors.New("Failed to run HADDOCK: " + err.Error())
-			return logF, err
-		}
+		logF, _ = j.RunHaddock24(cmd)
+		// if err != nil {
+		// 	err := errors.New("Failed to run HADDOCK: " + err.Error())
+		// 	return logF, err
+		// }
 	case 3:
 		logF, err = j.RunHaddock3(cmd)
 		if err != nil {
@@ -173,7 +171,7 @@ func (j Job) Run(version int, cmd string) (string, error) {
 
 }
 
-func (j *Job) GetStatus(version int) {
+func (j *Job) GetStatus(version int) error {
 
 	var logF string
 	var positiveKeys []string
@@ -187,44 +185,45 @@ func (j *Job) GetStatus(version int) {
 	} else if version == 3 {
 		logF = filepath.Join(j.Path, "run1", "log")
 		negativeKeys = []string{"ERROR"}
-		positiveKeys = []string{"Finished at"}
+		positiveKeys = []string{"This HADDOCK3 run took"}
 
 	} else {
 		err := errors.New("invalid HADDOCK version")
-		glog.Exit(err.Error())
+		return err
 	}
 
 	// Check if the log file exists
 	_, err := os.Stat(logF)
 	if os.IsNotExist(err) {
 		j.Status = status.QUEUED
-		return
+		return nil
 	}
 
 	// Check if the log file contains any of the negative keys
 	for _, k := range negativeKeys {
-		found, err := utils.SearchInLog(logF, k)
-		if err != nil {
-			glog.Exit(err.Error())
-		}
+		found, _ := utils.SearchInLog(logF, k)
+		// if err != nil {
+		// 	return err
+		// }
 		if found {
 			j.Status = status.FAILED
-			return
+			return nil
 		}
 	}
 
 	// Check if the log file contains any of the positive keys
 	for _, k := range positiveKeys {
-		found, err := utils.SearchInLog(logF, k)
-		if err != nil {
-			glog.Exit(err.Error())
-		}
+		found, _ := utils.SearchInLog(logF, k)
+		// if err != nil {
+		// 	return err
+		// }
 		if found {
 			j.Status = status.DONE
-			return
+			return nil
 		}
 	}
 
 	j.Status = status.INCOMPLETE
+	return nil
 
 }

--- a/runner/jobs_test.go
+++ b/runner/jobs_test.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"haddockrunner/input"
 	"os"
-	"path/filepath"
 	"testing"
 )
 
@@ -168,129 +167,6 @@ func TestJob_SetupHaddock24(t *testing.T) {
 			}
 			if err := j.SetupHaddock24(tt.args.cmd); (err != nil) != tt.wantErr {
 				t.Errorf("Job.SetupHaddock24() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
-func TestStatusHaddock24(t *testing.T) {
-
-	// Create a temporary path
-	tempDir, err := os.MkdirTemp("", "test_status24")
-	if err != nil {
-		t.Errorf("Error creating temp dir: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
-
-	// Write the key string to the log file
-	key := "Finishing HADDOCK on:"
-	logF := filepath.Join(tempDir, "run1", "haddock.out")
-	_ = os.MkdirAll(filepath.Dir(logF), 0755)
-	err = os.WriteFile(logF, []byte(key), 0644)
-	if err != nil {
-		t.Errorf("Failed to write file: %s", err)
-	}
-	defer os.Remove(logF)
-
-	type fields struct {
-		Path string
-	}
-	tests := []struct {
-		name           string
-		fields         fields
-		wantIncomplete bool
-		wantFinished   bool
-	}{
-		{
-			name: "pass",
-			fields: fields{
-				Path: tempDir,
-			},
-			wantIncomplete: false,
-			wantFinished:   true,
-		},
-		{
-			name: "fail",
-			fields: fields{
-				Path: "does-not-exist",
-			},
-			wantIncomplete: true,
-			wantFinished:   false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			j := Job{
-				Path: tt.fields.Path,
-			}
-			j.StatusHaddock24()
-			if j.Status.Incomplete != tt.wantIncomplete {
-				t.Errorf("Job.StatusHaddock24() gotFailed = %v, want %v", j.Status.Incomplete, tt.wantIncomplete)
-			}
-			if j.Status.Finished != tt.wantFinished {
-				t.Errorf("Job.StatusHaddock24() gotFinished = %v, want %v", j.Status.Finished, tt.wantFinished)
-			}
-		})
-	}
-
-}
-
-func TestStatusHaddock3(t *testing.T) {
-
-	// Create a temporary path
-	tempDir, err := os.MkdirTemp("", "test_status3")
-	if err != nil {
-		t.Errorf("Error creating temp dir: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
-
-	// Write the key string to the log file
-	key := "An error has occurred"
-	logF := filepath.Join(tempDir, "run1", "log")
-	_ = os.MkdirAll(filepath.Dir(logF), 0755)
-	err = os.WriteFile(logF, []byte(key), 0644)
-	if err != nil {
-		t.Errorf("Failed to write file: %s", err)
-	}
-	defer os.Remove(logF)
-
-	type fields struct {
-		Path string
-	}
-	tests := []struct {
-		name           string
-		fields         fields
-		wantIncomplete bool
-		wantFinished   bool
-	}{
-		{
-			name: "pass",
-			fields: fields{
-				Path: tempDir,
-			},
-			wantIncomplete: false,
-			wantFinished:   true,
-		},
-		{
-			name: "fail",
-			fields: fields{
-				Path: "does-not-exist",
-			},
-			wantIncomplete: true,
-			wantFinished:   false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			j := Job{
-				Path: tt.fields.Path,
-			}
-			j.StatusHaddock3()
-			if j.Status.Incomplete != tt.wantIncomplete {
-				t.Errorf("Job.StatusHaddock3() gotIncomplete = %v, want %v", j.Status.Incomplete, tt.wantIncomplete)
-			}
-			if j.Status.Finished != tt.wantFinished {
-				t.Errorf("Job.StatusHaddock3() gotFinished = %v, want %v", j.Status.Finished, tt.wantFinished)
 			}
 		})
 	}

--- a/runner/jobs_test.go
+++ b/runner/jobs_test.go
@@ -77,10 +77,17 @@ func TestJob_SetupHaddock24(t *testing.T) {
 
 	// Create a test directory
 	testD := "cmd-test"
-	_ = os.MkdirAll(testD, 0755)
+	err := os.MkdirAll(testD, 0755)
+	if err != nil {
+		t.Errorf("Error creating test directory: %v", err)
+	}
+
 	defer os.RemoveAll(testD)
 
-	setupHaddock24ForTest(testD)
+	err = setupHaddock24ForTest(testD)
+	if err != nil {
+		t.Errorf("Error setting up test directory: %v", err)
+	}
 
 	type fields struct {
 		ID         string
@@ -173,8 +180,12 @@ func TestJob_SetupHaddock24(t *testing.T) {
 func TestJobRun(t *testing.T) {
 
 	temptestP, _ := os.MkdirTemp("", "test-job-run")
-	setupHaddock24ForTest(temptestP)
 	defer os.RemoveAll(temptestP)
+
+	err := setupHaddock24ForTest(temptestP)
+	if err != nil {
+		t.Errorf("Error setting up test directory: %v", err)
+	}
 
 	type fields struct {
 		j Job
@@ -271,28 +282,40 @@ func TestJobGetStatus(t *testing.T) {
 	// Setup the positive test for v2
 	v2PositiveTempD, _ := os.MkdirTemp("", "v2-positive")
 	defer os.RemoveAll(v2PositiveTempD)
-	os.MkdirAll(filepath.Join(v2PositiveTempD, "run1"), 0755)
+	err := os.MkdirAll(filepath.Join(v2PositiveTempD, "run1"), 0755)
+	if err != nil {
+		t.Errorf("Error creating test directory: %v", err)
+	}
 	logF := filepath.Join(v2PositiveTempD, "run1", "haddock.out")
 	_ = os.WriteFile(logF, []byte("Finishing HADDOCK on:"), 0644)
 
 	// Setup the negative test for v2
 	v2NegativeTempD, _ := os.MkdirTemp("", "v2-negative")
 	defer os.RemoveAll(v2NegativeTempD)
-	os.MkdirAll(filepath.Join(v2NegativeTempD, "run1"), 0755)
+	err = os.MkdirAll(filepath.Join(v2NegativeTempD, "run1"), 0755)
+	if err != nil {
+		t.Errorf("Error creating test directory: %v", err)
+	}
 	logF = filepath.Join(v2NegativeTempD, "run1", "haddock.out")
 	_ = os.WriteFile(logF, []byte("An error has occurred"), 0644)
 
 	// Setup the positive test for v3
 	v3PositiveTempD, _ := os.MkdirTemp("", "v3-positive")
 	defer os.RemoveAll(v3PositiveTempD)
-	os.MkdirAll(filepath.Join(v3PositiveTempD, "run1"), 0755)
+	err = os.MkdirAll(filepath.Join(v3PositiveTempD, "run1"), 0755)
+	if err != nil {
+		t.Errorf("Error creating test directory: %v", err)
+	}
 	logF = filepath.Join(v3PositiveTempD, "run1", "log")
 	_ = os.WriteFile(logF, []byte("This HADDOCK3 run took"), 0644)
 
 	// Setup the incomplete scenario
 	incompleteTempD, _ := os.MkdirTemp("", "incomplete")
 	defer os.RemoveAll(incompleteTempD)
-	os.MkdirAll(filepath.Join(incompleteTempD, "run1"), 0755)
+	err = os.MkdirAll(filepath.Join(incompleteTempD, "run1"), 0755)
+	if err != nil {
+		t.Errorf("Error creating test directory: %v", err)
+	}
 	logF = filepath.Join(incompleteTempD, "run1", "log")
 	_ = os.WriteFile(logF, []byte(""), 0644)
 

--- a/runner/jobs_test.go
+++ b/runner/jobs_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"haddockrunner/input"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -167,6 +168,129 @@ func TestJob_SetupHaddock24(t *testing.T) {
 			}
 			if err := j.SetupHaddock24(tt.args.cmd); (err != nil) != tt.wantErr {
 				t.Errorf("Job.SetupHaddock24() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestStatusHaddock24(t *testing.T) {
+
+	// Create a temporary path
+	tempDir, err := os.MkdirTemp("", "test_status24")
+	if err != nil {
+		t.Errorf("Error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Write the key string to the log file
+	key := "Finishing HADDOCK on:"
+	logF := filepath.Join(tempDir, "run1", "haddock.out")
+	_ = os.MkdirAll(filepath.Dir(logF), 0755)
+	err = os.WriteFile(logF, []byte(key), 0644)
+	if err != nil {
+		t.Errorf("Failed to write file: %s", err)
+	}
+	defer os.Remove(logF)
+
+	type fields struct {
+		Path string
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		wantIncomplete bool
+		wantFinished   bool
+	}{
+		{
+			name: "pass",
+			fields: fields{
+				Path: tempDir,
+			},
+			wantIncomplete: false,
+			wantFinished:   true,
+		},
+		{
+			name: "fail",
+			fields: fields{
+				Path: "does-not-exist",
+			},
+			wantIncomplete: true,
+			wantFinished:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			j := Job{
+				Path: tt.fields.Path,
+			}
+			j.StatusHaddock24()
+			if j.Status.Incomplete != tt.wantIncomplete {
+				t.Errorf("Job.StatusHaddock24() gotFailed = %v, want %v", j.Status.Incomplete, tt.wantIncomplete)
+			}
+			if j.Status.Finished != tt.wantFinished {
+				t.Errorf("Job.StatusHaddock24() gotFinished = %v, want %v", j.Status.Finished, tt.wantFinished)
+			}
+		})
+	}
+
+}
+
+func TestStatusHaddock3(t *testing.T) {
+
+	// Create a temporary path
+	tempDir, err := os.MkdirTemp("", "test_status3")
+	if err != nil {
+		t.Errorf("Error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Write the key string to the log file
+	key := "An error has occurred"
+	logF := filepath.Join(tempDir, "run1", "log")
+	_ = os.MkdirAll(filepath.Dir(logF), 0755)
+	err = os.WriteFile(logF, []byte(key), 0644)
+	if err != nil {
+		t.Errorf("Failed to write file: %s", err)
+	}
+	defer os.Remove(logF)
+
+	type fields struct {
+		Path string
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		wantIncomplete bool
+		wantFinished   bool
+	}{
+		{
+			name: "pass",
+			fields: fields{
+				Path: tempDir,
+			},
+			wantIncomplete: false,
+			wantFinished:   true,
+		},
+		{
+			name: "fail",
+			fields: fields{
+				Path: "does-not-exist",
+			},
+			wantIncomplete: true,
+			wantFinished:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			j := Job{
+				Path: tt.fields.Path,
+			}
+			j.StatusHaddock3()
+			if j.Status.Incomplete != tt.wantIncomplete {
+				t.Errorf("Job.StatusHaddock3() gotIncomplete = %v, want %v", j.Status.Incomplete, tt.wantIncomplete)
+			}
+			if j.Status.Finished != tt.wantFinished {
+				t.Errorf("Job.StatusHaddock3() gotFinished = %v, want %v", j.Status.Finished, tt.wantFinished)
 			}
 		})
 	}

--- a/runner/jobs_test.go
+++ b/runner/jobs_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"haddockrunner/input"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -73,6 +74,14 @@ func TestRunHaddock3(t *testing.T) {
 }
 
 func TestJob_SetupHaddock24(t *testing.T) {
+
+	// Create a test directory
+	testD := "cmd-test"
+	_ = os.MkdirAll(testD, 0755)
+	defer os.RemoveAll(testD)
+
+	setupHaddock24ForTest(testD)
+
 	type fields struct {
 		ID         string
 		Path       string
@@ -144,18 +153,7 @@ func TestJob_SetupHaddock24(t *testing.T) {
 			wantErr: true,
 		},
 	}
-	_ = os.MkdirAll("cmd-test/run1/structures/it0", 0755)
-	_ = os.MkdirAll("cmd-test/run1/structures/it1/water", 0755)
-	_ = os.MkdirAll("cmd-test/run1/data/distances", 0755)
-	_ = os.MkdirAll("cmd-test/run1/toppar", 0755)
-	defer os.RemoveAll("cmd-test")
 
-	_ = os.WriteFile("cmd-test/run1/run.cns", []byte("{===>} param1=true;"), 0644)
-
-	for _, f := range []string{"cmd-test/run.param", "ambig.tbl", "unambig.tbl", "gdp.top", "gdp.param"} {
-		_ = os.WriteFile(f, []byte(""), 0644)
-		defer os.Remove(f)
-	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			j := Job{
@@ -170,4 +168,251 @@ func TestJob_SetupHaddock24(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestJobRun(t *testing.T) {
+
+	temptestP, _ := os.MkdirTemp("", "test-job-run")
+	setupHaddock24ForTest(temptestP)
+	defer os.RemoveAll(temptestP)
+
+	type fields struct {
+		j Job
+	}
+	type args struct {
+		version int
+		cmd     string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "pass v2",
+			fields: fields{
+				j: Job{
+					Path: temptestP,
+				},
+			},
+			args: args{
+				version: 2,
+				cmd:     "echo test",
+			},
+			wantErr: false,
+		},
+		{
+			name: "pass v3",
+			fields: fields{
+				j: Job{},
+			},
+			args: args{
+				version: 3,
+				cmd:     "echo test",
+			},
+			wantErr: false,
+		},
+		{
+			name: "fail v2",
+			fields: fields{
+				j: Job{
+					Path: "non-existing-path",
+				},
+			},
+			args: args{
+				version: 2,
+				cmd:     "echo test",
+			},
+			wantErr: true,
+		},
+		{
+			name: "fail v3",
+			fields: fields{
+				j: Job{
+					Path: "non-existing-path",
+				},
+			},
+			args: args{
+				version: 3,
+				cmd:     "echo test",
+			},
+			wantErr: true,
+		},
+		{
+			name: "fail v2 with non-existing command",
+			fields: fields{
+				j: Job{
+					Path: temptestP,
+				},
+			},
+			args: args{
+				version: 2,
+				cmd:     "non_existing_command",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			_, err := tt.fields.j.Run(tt.args.version, tt.args.cmd)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Job.Run() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+		})
+	}
+}
+
+func TestJobGetStatus(t *testing.T) {
+
+	// Setup the positive test for v2
+	v2PositiveTempD, _ := os.MkdirTemp("", "v2-positive")
+	defer os.RemoveAll(v2PositiveTempD)
+	os.MkdirAll(filepath.Join(v2PositiveTempD, "run1"), 0755)
+	logF := filepath.Join(v2PositiveTempD, "run1", "haddock.out")
+	_ = os.WriteFile(logF, []byte("Finishing HADDOCK on:"), 0644)
+
+	// Setup the negative test for v2
+	v2NegativeTempD, _ := os.MkdirTemp("", "v2-negative")
+	defer os.RemoveAll(v2NegativeTempD)
+	os.MkdirAll(filepath.Join(v2NegativeTempD, "run1"), 0755)
+	logF = filepath.Join(v2NegativeTempD, "run1", "haddock.out")
+	_ = os.WriteFile(logF, []byte("An error has occurred"), 0644)
+
+	// Setup the positive test for v3
+	v3PositiveTempD, _ := os.MkdirTemp("", "v3-positive")
+	defer os.RemoveAll(v3PositiveTempD)
+	os.MkdirAll(filepath.Join(v3PositiveTempD, "run1"), 0755)
+	logF = filepath.Join(v3PositiveTempD, "run1", "log")
+	_ = os.WriteFile(logF, []byte("This HADDOCK3 run took"), 0644)
+
+	// Setup the incomplete scenario
+	incompleteTempD, _ := os.MkdirTemp("", "incomplete")
+	defer os.RemoveAll(incompleteTempD)
+	os.MkdirAll(filepath.Join(incompleteTempD, "run1"), 0755)
+	logF = filepath.Join(incompleteTempD, "run1", "log")
+	_ = os.WriteFile(logF, []byte(""), 0644)
+
+	type fields struct {
+		j Job
+	}
+	type args struct {
+		version int
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "pass v2 positive",
+			fields: fields{
+				j: Job{
+					Path: v2PositiveTempD,
+				},
+			},
+			args: args{
+				version: 2,
+			},
+			wantErr: false,
+		},
+		{
+			name: "pass v2 negative",
+			fields: fields{
+				j: Job{
+					Path: v2NegativeTempD,
+				},
+			},
+			args: args{
+				version: 2,
+			},
+			wantErr: false,
+		},
+		{
+			name: "pass v3 positive",
+			fields: fields{
+				j: Job{
+					Path: v3PositiveTempD,
+				},
+			},
+			args: args{
+				version: 3,
+			},
+			wantErr: false,
+		},
+		{
+			name: "fail with invalid version",
+			fields: fields{
+				j: Job{
+					Path: v2PositiveTempD,
+				},
+			},
+			args: args{
+				version: 0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "pass with incomplete v3",
+			fields: fields{
+				j: Job{
+					Path: incompleteTempD,
+				},
+			},
+			args: args{
+				version: 3,
+			},
+			wantErr: false,
+		},
+		{
+			name: "pass without log file",
+			fields: fields{
+				j: Job{
+					Path: "non-existing-path",
+				},
+			},
+			args: args{
+				version: 3,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			err := tt.fields.j.GetStatus(tt.args.version)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Job.GetStatus() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+		})
+	}
+}
+
+// setupHaddock24ForTest is a helper function that creates a directory structure for testing
+//
+// Note: This could be a Mock- feel free to change it (:
+func setupHaddock24ForTest(p string) error {
+	_ = os.MkdirAll(filepath.Join(p, "run1/structures/it0"), 0755)
+	_ = os.MkdirAll(filepath.Join(p, "run1/structures/it1/water"), 0755)
+	_ = os.MkdirAll(filepath.Join(p, "run1/data/distances"), 0755)
+	_ = os.MkdirAll(filepath.Join(p, "run1/toppar"), 0755)
+	_ = os.WriteFile(filepath.Join(p, "run1/run.cns"), []byte("{===>} param1=true;"), 0644)
+	inputF := []string{
+		filepath.Join(p, "run.param"),
+		filepath.Join(p, "ambig.tbl"),
+		filepath.Join(p, "unambig.tbl"),
+		filepath.Join(p, "gdp.top"),
+		filepath.Join(p, "gdp.param"),
+	}
+
+	for _, f := range inputF {
+		_ = os.WriteFile(f, []byte(""), 0644)
+	}
+	return nil
 }

--- a/runner/status/status.go
+++ b/runner/status/status.go
@@ -1,7 +1,9 @@
 package status
 
-type Status struct {
-	Finished   bool
-	Incomplete bool
-	Failed     bool
-}
+const (
+	DONE       = "DONE"
+	FAILED     = "FAILED"
+	QUEUED     = "QUEUED"
+	INCOMPLETE = "INCOMPLETE"
+	UNKNOWN    = "UNKNOWN"
+)

--- a/runner/status/status.go
+++ b/runner/status/status.go
@@ -1,0 +1,7 @@
+package status
+
+type Status struct {
+	Finished   bool
+	Incomplete bool
+	Failed     bool
+}

--- a/utils/checksum/checksum.go
+++ b/utils/checksum/checksum.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"crypto/md5"
 	"encoding/hex"
+	"errors"
 	"io"
 	"os"
 )
@@ -134,7 +135,7 @@ func ValidateChecksum(inputF, inputL, checksumF string) (bool, error) {
 	// }
 
 	if !AreEqual(c, oldChecksum) {
-		return false, nil
+		return false, errors.New("the input files have changed since the last run. Remove " + checksumF + " to force a fresh run.")
 	} else {
 		return true, nil
 	}

--- a/utils/checksum/checksum_test.go
+++ b/utils/checksum/checksum_test.go
@@ -373,6 +373,8 @@ func TestValidateChecksum(t *testing.T) {
 				inputL:    tempF.Name(),
 				checksumF: differentChecksumF,
 			},
+			want:    false,
+			wantErr: true,
 		},
 	}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -218,3 +218,22 @@ func FindFname(arr []string, pattern *regexp.Regexp) (string, error) {
 
 	return fname, nil
 }
+
+func SearchInLog(filePath, searchString string) (bool, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return false, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, searchString) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -332,3 +332,72 @@ func TestFindFname(t *testing.T) {
 	}
 
 }
+
+func TestSearchInLog(t *testing.T) {
+	// Create a dummy log file
+	tempF, err := os.CreateTemp("", "temp_log")
+	if err != nil {
+		t.Errorf("Failed to create temp file: %s", err)
+	}
+	defer os.Remove(tempF.Name())
+
+	// Write the key string to the log file
+	key := "Finishing HADDOCK on:"
+	err = os.WriteFile(tempF.Name(), []byte(key), 0644)
+	if err != nil {
+		t.Errorf("Failed to write file: %s", err)
+	}
+
+	type args struct {
+		filePath     string
+		searchString string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "pass by finding the string",
+			args: args{
+				filePath:     tempF.Name(),
+				searchString: key,
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "fail by not finding the string",
+			args: args{
+				filePath:     tempF.Name(),
+				searchString: "not found",
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "fail by passing a file that does not exist",
+			args: args{
+				filePath:     "does-not-exist",
+				searchString: "not found",
+			},
+			want:    false,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SearchInLog(tt.args.filePath, tt.args.searchString)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SearchInLog() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("SearchInLog() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
This PR adds logic to get the state of a running job, useful for re-starting the benchmark; see my comment below for a better explanation of the logic.