### PR TITLE
Don't allow SLURML scheduler to be used together with `mode=batch`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,7 +32,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
 #==============================================================================================
 # Install miniconda
 ENV CONDA_DIR /opt/conda
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh  \
+RUN wget --quiet --no-check-certificate https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh  \
   && /bin/bash ~/miniconda.sh -b -p /opt/conda
 
 ENV PATH=$CONDA_DIR/bin:$PATH

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,6 @@
     "dockerfile": "Dockerfile",
   },
   "features": {
-    "ghcr.io/devcontainers/features/go:1": {},
     "ghcr.io/devcontainers/features/git:1": {},
   },
   "postCreateCommand": "sudo bash /app/start.sh",

--- a/example/example_haddock30.yml
+++ b/example/example_haddock30.yml
@@ -50,7 +50,7 @@ scenarios:
         topoaa:
           autohis: true
         rigidbody:
-          sampling: 2
+          sampling: 5
           cmrest: true
 
   - name: random-restraints
@@ -64,7 +64,7 @@ scenarios:
         topoaa:
           autohis: true
         rigidbody:
-          sampling: 2
+          sampling: 5
           ranair: true
 
   #-----------------------------------------------

--- a/input/input.go
+++ b/input/input.go
@@ -226,16 +226,16 @@ func ValidateRunCNSParams(known map[string]interface{}, params map[string]interf
 // ValidateExecutionModes checks if the execution modes are valid
 func (inp *Input) ValidateExecutionModes() error {
 
-	if inp.Slurm == (SlurmParams{}) {
+	if inp.Slurm != (SlurmParams{}) {
 		// Check if the executable is HADDOCK3
 		if utils.IsHaddock24(inp.General.HaddockDir) {
-			err := errors.New("cannot use `use_slurm` with HADDOCK2")
+			err := errors.New("cannot use SLURM with HADDOCK2")
 			return err
 		} else if utils.IsHaddock3(inp.General.HaddockDir) {
 			// We need to check if the Scenarios are using the correct execution modes
 			for _, scenario := range inp.Scenarios {
 				if scenario.Parameters.General["mode"] != "local" {
-					err := errors.New("cannot use `use_slurm` with `mode: " + scenario.Parameters.General["mode"].(string) + "`")
+					err := errors.New("SLURM can only be used with `mode: local`")
 					return err
 				}
 			}

--- a/input/input_test.go
+++ b/input/input_test.go
@@ -675,6 +675,7 @@ func TestValidateExecutionModes(t *testing.T) {
 
 	type fields struct {
 		General   GeneralStruct
+		Slurm     SlurmParams
 		Scenarios []Scenario
 	}
 	tests := []struct {
@@ -687,6 +688,9 @@ func TestValidateExecutionModes(t *testing.T) {
 			fields: fields{
 				General: GeneralStruct{
 					HaddockDir: haddock3Dir,
+				},
+				Slurm: SlurmParams{
+					Cpus_per_task: 42,
 				},
 				Scenarios: []Scenario{
 					{
@@ -707,6 +711,9 @@ func TestValidateExecutionModes(t *testing.T) {
 				General: GeneralStruct{
 					HaddockDir: haddock2Dir,
 				},
+				Slurm: SlurmParams{
+					Cpus_per_task: 42,
+				},
 				Scenarios: []Scenario{},
 			},
 			wantErr: true,
@@ -717,12 +724,15 @@ func TestValidateExecutionModes(t *testing.T) {
 				General: GeneralStruct{
 					HaddockDir: haddock3Dir,
 				},
+				Slurm: SlurmParams{
+					Cpus_per_task: 42,
+				},
 				Scenarios: []Scenario{
 					{
 						Name: "true-interface",
 						Parameters: ParametersStruct{
 							General: map[string]any{
-								"mode": "anything",
+								"mode": "batch",
 							},
 						},
 					},
@@ -730,11 +740,34 @@ func TestValidateExecutionModes(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "valid-haddock3",
+			fields: fields{
+				General: GeneralStruct{
+					HaddockDir: haddock3Dir,
+				},
+				Slurm: SlurmParams{
+					Cpus_per_task: 42,
+				},
+				Scenarios: []Scenario{
+					{
+						Name: "true-interface",
+						Parameters: ParametersStruct{
+							General: map[string]any{
+								"mode": "local",
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		inp := &Input{
 			General:   tt.fields.General,
 			Scenarios: tt.fields.Scenarios,
+			Slurm:     tt.fields.Slurm,
 		}
 		if err := inp.ValidateExecutionModes(); (err != nil) != tt.wantErr {
 			t.Errorf("Input.ValidateExecutionModes() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
This PR fixed a bug in `ValidateExecutionModes` in which the check for the combination of running mode/slurm defined in the `benchmark.yaml` was not being checked.

This is relevant because combining both of these modes can cause an exponential resource usage