### PR TITLE
Fix documentation typos

### DIFF
--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -1,6 +1,6 @@
 # Development
 
-The [code repository](https://github.com/haddocking/haddock-runner) contains a DevContainer configuration that can be used to setup a development environment, have a look at [Developing inside a Container](https://code.visualstudio.com/docs/devcontainers/containers) for more information.
+The [code repository](https://github.com/haddocking/haddock-runner) contains a DevContainer configuration that can be used to set up a development environment, have a look at [Developing inside a Container](https://code.visualstudio.com/docs/devcontainers/containers) for more information.
 
 The only caveat is that a `cns` binary must be in the `.devcontainer` path before building the container.
 

--- a/docs/src/home.md
+++ b/docs/src/home.md
@@ -2,7 +2,7 @@
 
 ![image](./banner_home-mini.jpg)
 
-The `haddock-runner` is an effort to reduce code duplication and to streamline the execution of HADDOCK benchmark.
+The `haddock-runner` is an effort to reduce code duplication and to streamline the execution of HADDOCK benchmarks.
 
 It is a standalone program, freely available at [https://github.com/haddocking/haddock-runner](https://github.com/haddocking/haddock-runner).
 

--- a/docs/src/how-does-it-work.md
+++ b/docs/src/how-does-it-work.md
@@ -2,11 +2,11 @@
 
 The execution of the `haddock-runner` consists of a few steps:
 
-1. Setup the benchmark
+1. Set up the benchmark
 
    - Copy the target structures to the location where the HADDOCK run will be executed
 
-2. Setup the HADDOCK run
+2. Set up the HADDOCK run
    - For HADDOCK2.4, writing the `run.param` file and executing the `haddock2.4` program once to setup the folder structure
    - For HADDOCK3, writing the `run.toml`
 3. Distribute several HADDOCK runs in a HPC-friendly manner

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -1,8 +1,8 @@
 # Installation
 
-The tool is designed for users/students/developers that are familiar with HADDOCK, command-line scripting and with access to a HPC infrastructure.
+The tool is designed for users/students/developers that are familiar with HADDOCK and command-line scripting, and have access to an HPC infrastructure.
 
-If this is the first time you are using HADDOCK, please familiarize first yourself with the software by running the basic [HADDOCK2.4](/education/HADDOCK24/index.md) or [HADDOCK3](/education/HADDOCK3/index.md) tutorials.
+If this is the first time you are using HADDOCK, please first familiarize yourself with the software by running the basic [HADDOCK2.4](/education/HADDOCK24/index.md) or [HADDOCK3](/education/HADDOCK3/index.md) tutorials.
 
 This tool is not meant to be used by end-users who want to run a single target, or a small set of targets; for that purpose we recommend instead using the [HADDOCK2.4 web server](https://wenmr.science.uu.nl/haddock2.4/).
 
@@ -12,7 +12,7 @@ This tool is not meant to be used by end-users who want to run a single target, 
 
 `haddock-runner` is a standalone open-source software licensed under Apache 2.0 and freely available from the following repository: [github.com/haddocking/haddock-runner](https://github.com/haddocking/haddock-runner).
 
-To us it simply download the latest binary from the [releases page](https://github.com/haddocking/haddock-runner/releases):
+To use it simply download the latest binary from the [releases page](https://github.com/haddocking/haddock-runner/releases):
 
 ```bash
 $ wget https://github.com/haddocking/haddock-runner/releases/download/v1.10.0/haddock-runner_1.10.0_linux_386.tar.gz

--- a/docs/src/restarting-a-benchmark.md
+++ b/docs/src/restarting-a-benchmark.md
@@ -31,4 +31,4 @@ I1116 13:30:40.741859   58085 main.go:226] 1A2K_true-interface - DONE in 151.02 
 I1116 13:30:40.741907   58085 main.go:235] ############################################
 ```
 
-To make sure the results are consistent, it will create a checksum of both the configuration yaml and of the input txt and show you a warning. This ensures that parameters and input has not changed mid-execution.
+To make sure the results are consistent, it will create a checksum of both `benchmark.yaml` and of `input.list` and show you a warning. This ensures that parameters and input have not changed mid-execution.

--- a/docs/src/setting-up-bm5.md
+++ b/docs/src/setting-up-bm5.md
@@ -1,12 +1,12 @@
 # Setting up BM5
 
-The Protein-Protein docking benchmark v5 ([Vreven, 2015](https://doi.org/10.1016/j.jmb.2015.07.016)), namely BM5, contains a is a large set of non-redundat high-quality structures, check [here](https://zlab.umassmed.edu/benchmark/) the full set.
+Protein-protein docking benchmark v5 ([Vreven, 2015](https://doi.org/10.1016/j.jmb.2015.07.016)), referred to as BM5, is a large set of non-redundant high-quality structures. The full set can be found [here](https://zlab.umassmed.edu/benchmark/).
 
-The BonvinLab provides a HADDOCK-ready sub-version of the BM5 which can be easily used as input for `haddock-runner`. This version is available the following repository; [github.com/haddocking/BM5-clean](https://github.com/haddocking/BM5-clean). Below we will go over step-by-step instructions on how to use it as input.
+The BonvinLab provides a HADDOCK-ready sub-version of the BM5 which can be easily used as input for `haddock-runner`. This version is available from the following repository: [github.com/haddocking/BM5-clean](https://github.com/haddocking/BM5-clean). Below we will go over step-by-step instructions on how to use it as input.
 
 ## Create a working directory
 
-Create a working directory and change to it;
+Create a working directory and change to it:
 
 ```bash
 mkdir -p ~/projects/benchmarking && cd ~/projects/benchmarking
@@ -16,7 +16,7 @@ mkdir -p ~/projects/benchmarking && cd ~/projects/benchmarking
 
 Clone the repository and checkout a version. Note that its always recomended to use a specific version, as the main branch might change and for reproducibility.
 
-As previously mentioned, the `BM5-clean` repository is already an organized sub-version, thus its very simple to create the `bm5-input.list` file with a few bash commands;
+As previously mentioned, the `BM5-clean` repository is already an organized sub-version, thus it's very simple to create the `bm5-input.list` file with a few bash commands:
 
 ```bash
 git clone https://github.com/haddocking/BM5-clean.git ~/projects/benchmarking/BM5-clean && \
@@ -29,7 +29,7 @@ git clone https://github.com/haddocking/BM5-clean.git ~/projects/benchmarking/BM
 
 ## Prepare a `haddock3.sh` script
 
-See below an example of a `haddock3.sh` script that can be used to run HADDOCK3.0 locally;
+See below an example of a `haddock3.sh` script that can be used to run HADDOCK3.0 locally:
 
 ```bash
 #!/bin/bash
@@ -38,7 +38,7 @@ conda activate env
 haddock3 "$@"
 ```
 
-Make sure to make this script executable;
+Make sure to make this script executable:
 
 ```bash
 chmod +x ~/projects/benchmarking/haddock3.sh
@@ -128,7 +128,7 @@ scenarios:
 
 ## Run the benchmarking
 
-Finally, run the benchmarking with the following command;
+Finally, run the benchmark with the following command:
 
 ```bash
 haddock-runner bm5.yaml

--- a/docs/src/writing-a-benchmark.yaml-file.md
+++ b/docs/src/writing-a-benchmark.yaml-file.md
@@ -1,21 +1,21 @@
 # Writing a benchmark.yaml file
 
-The `benchmark.yaml` file is a configuration file in [`YAML`](https://yaml.org/) format that will be used by `haddock-runner` to run the benchmark. The whole idea is that one configuration file can define multiple scenarios, each scenario being a set of parameters that will be used to run HADDOCK.
+The `benchmark.yaml` file is a configuration file in [`YAML`](https://yaml.org/) format that will be used by `haddock-runner` to run the benchmark. The central idea is that one configuration file can define multiple scenarios, each scenario being a set of parameters that will be used to run HADDOCK.
 
 This file should be the replicable part of the benchmark, i.e. the part that you want to share with others. It should contain all the information needed to run the benchmark, alongside the input list.
 
-This file is divided in 3 main sections; [`general`](#general-section), [`slurm`](#slurm-section) and [`scenarios`](#scenario-section).
+This file is divided into 3 main sections: [`general`](#general-section), [`slurm`](#slurm-section) and [`scenarios`](#scenario-section).
 
 ## General section
 
 Here you must define the following parameters:
 
-- `executable`: Path to the `run-haddock.sh` script (see [here](./writing-a-run-haddock.sh-script.md) for more details).
+- `executable`: Path to the `run-haddock.sh` script (see [here](./writing-a-run-haddock.sh-script.md) for more details)
 - `max_concurrent`: Maximum number of jobs that can be executed at a given time
 - `haddock_dir`: Path to the HADDOCK installation, this is used to validate the parameters of the [`scenarios`](#scenario-section) section
-- `receptor_suffix`: This pattern will identify what is the receptor file in the the suffix used to identify the receptor files
+- `receptor_suffix`: This pattern will identify what is the receptor file
 - `ligand_suffix`: This will be used to identify the ligand files
-- `shape_suffix`: This will be used to identify the shape files
+- `shape_suffix`: This will be used to identify shape files
 - `input_list`: The path to the input list (see [here](./writing-a-input.list-file.md) for more details)
 - `work_dir`: The path where the results will be stored
 
@@ -34,7 +34,7 @@ general:
 
 ## Slurm section
 
-This section is option but highly recomended! For these to take effect you must be running the benchmark in a HPC environment. These will be used internally by the runner to compose the `.job` file. Here you can define the following parameters, if left blank, SLURM will pick up the default values:
+This section is optional but highly recomended! For these to take effect you must be running the benchmark in an HPC environment. These will be used internally by the runner to compose the `.job` file. Here you can define the following parameters or, if left blank, SLURM will pick up the default values:
 
 - `partition`: The name of the partition to be used
 - `cpus_per_task`: Number of CPUs per task
@@ -54,22 +54,22 @@ slurm:
 
 ## Scenario section
 
-Here you must define the scenarios that you want to run, these are slightly different for [HADDOCK2.4](#haddock24) and [HADDOCK3.0](#haddock30)
+Here you must define the scenarios that you want to run, which are slightly different for [HADDOCK2.4](#haddock24) and [HADDOCK3.0](#haddock30)
 
 ### HADDOCK2.4
 
 For HADDOCK2.4 you must define the following:
 
-- `name`: the name of the scenario
-- `parameters`: the parameters to be used in the scenario
-  - `run_cns`: parameters that will be used in the `run.cns` file
-  - `restraints`: patterns used to identify the restraints files
-    - `ambig`: pattern used to identify the ambiguous restraints file
-    - `unambig`: pattern used to identify the unambiguous restraints file
-    - `hbonds`: pattern used to identify the hydrogen bonds restraints file
-  - `custom_toppar`: patterns used to identify the custom topology files
-    - `topology`: pattern used to identify the topology file
-    - `param`: pattern used to identify the parameter file
+- `name`: The name of the scenario
+- `parameters`: The parameters to be used in the scenario (requires only those that differ from the default)
+  - `run_cns`: Parameters that will be used in the `run.cns` file
+  - `restraints`: Patterns used to identify the restraints files
+    - `ambig`: Pattern used to identify the ambiguous restraints file
+    - `unambig`: Pattern used to identify the unambiguous restraints file
+    - `hbonds`: Pattern used to identify the hydrogen bonds restraints file
+  - `custom_toppar`: Patterns used to identify the custom topology files
+    - `topology`: Pattern used to identify the topology file
+    - `param`: Pattern used to identify the parameter file
 
 ```yaml
 # HADDOCK2.4
@@ -92,12 +92,12 @@ scenarios:
 
 For HADDOCK3.0 you must define the following:
 
-- `name`: the name of the scenario
-- `parameters`: the parameters to be used in the scenario
-  - `general`: general parameters; those are the ones defined in the "top" section of the `run.toml` script
-  - `modules`: this subsection is related to the parameters of each module in HADDOCK3.0
-    - `order`: the order of the modules to be used in HADDOCK3.0
-    - `<module-name>`: parameters for the module
+- `name`: The name of the scenario
+- `parameters`: The parameters to be used in the scenario
+  - `general`: General parameters; those are the ones defined in the "top" section of the `run.toml` script
+  - `modules`: This subsection is related to the parameters of each module in HADDOCK3.0
+    - `order`: The order of the modules to be used in HADDOCK3.0
+    - `<module-name>`: Parameters for the module
 
 ```yaml
 # HADDOCK3.0

--- a/docs/src/writing-a-input.list-file.md
+++ b/docs/src/writing-a-input.list-file.md
@@ -1,6 +1,6 @@
-# Writing a `input.list` file
+# Writing an `input.list` file
 
-The input list is a flat text file with the paths of the targets;
+The input list is a flat text file with the paths of the targets:
 
 ```text
 # input.list
@@ -34,9 +34,9 @@ In this example the suffixes are:
 
 These suffixes are defined in the `benchmark.yaml` file, see [here](./writing-a-benchmark.yaml-file.md) for more details.
 
-The same logic applies to the restraints files, in the example above the pattern for the ambiguous restraint can be defined as `ambig: "ti"`, so the file `complex1_ti.tbl` will be used as the ambiguous restraint for the target `complex1`, `complex2_ti.tbl` for the target `complex2`, etc. See section 3.2.2 for information specific to the definition of restraints when setting up a HADDOCK3.0 run.
+The same logic applies to the restraints files: in the example above, the ambiguous restraints can be specified in the [`benchmark.yaml`](./writing-a-benchmark.yaml-file.md) file as `ambig: "ti"`, so the file `complex1_ti.tbl` will be used as the ambiguous restraint for the target `complex1`, `complex2_ti.tbl` for the target `complex2`, etc. See the [relevant section](./writing-a-benchmark.yaml-file.md#haddock30) for information specific to the definition of restraints when setting up a HADDOCK3.0 run.
 
-HADDOCK supports many modified amino acids/bases/glycans/ions (check the [full list](https://wenmr.science.uu.nl/haddock2.4/library)). However if your target molecule is not present in this library, you can also provide it following the same logic; `topology: "_ligand.top"` and `param: "_ligand.param"` will use the files `protein2_ligand.top` and `protein2_ligand.param` for the target `protein2`.
+HADDOCK supports many modified amino acids/bases/glycans/ions (check the [full list](https://wenmr.science.uu.nl/haddock2.4/library)). However if your target molecule is not present in this library, you can also provide it following the same logic: `topology: "_ligand.top"` and `param: "_ligand.param"` will use the files `protein2_ligand.top` and `protein2_ligand.param` for the target `protein2`.
 
 > **IMPORTANT**: For ensembles, **provide each model individually** and append a number to the suffix, for example: `complex1_l_u_1.pdb`, `complex1_l_u_2.pdb`, etc.
 


### PR DESCRIPTION
Some small suggestions to fix typos, and adjust some phrasing and punctuation, in the documentation.