### PR TITLE
add error message for empty parameters

### DIFF
--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -215,7 +215,7 @@ func (t *Target) SetupHaddock3Scenario(wd string, s input.Scenario) (runner.Job,
 }
 
 // WriteRunToml writes the run.toml file
-func (t *Target) WriteRunToml(projectDir string, general map[string]interface{}, mod input.ModuleParams) (string, error) {
+func (t *Target) WriteRunToml(projectDir string, general map[string]any, mod input.ModuleParams) (string, error) {
 	runTomlString := ""
 	for k, v := range general {
 		switch v := v.(type) {
@@ -284,7 +284,11 @@ func (t *Target) WriteRunToml(projectDir string, general map[string]interface{},
 					m = "'" + m + "'"
 				}
 				runTomlString += "[" + m + "]\n"
-				for k, v := range field.Interface().(map[string]interface{}) {
+				for k, v := range field.Interface().(map[string]any) {
+					// Check if v is nil
+					if v == nil {
+						return "", errors.New("Parameter " + k + " is empty (nil), please check your input")
+					}
 					// Find the file to be used as fname
 					if strings.Contains(k, "_fname") {
 						pattern := regexp.MustCompile(v.(string))
@@ -316,7 +320,7 @@ func (t *Target) WriteRunToml(projectDir string, general map[string]interface{},
 							runTomlString += k + " = [" + strings.Join(utils.IntSliceToStringSlice(v), ",") + "]\n"
 						case []float64:
 							runTomlString += k + " = [" + strings.Join(utils.FloatSliceToStringSlice(v), ",") + "]\n"
-						case []interface{}:
+						case []any:
 							runTomlString += k + " = [" + strings.Join(utils.InterfaceSliceToStringSlice(v), ",") + "]\n"
 						}
 					}

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -740,7 +740,7 @@ func TestTarget_WriteRunToml(t *testing.T) {
 	}
 	type args struct {
 		projectDir string
-		general    map[string]interface{}
+		general    map[string]any
 		mod        input.ModuleParams
 	}
 	tests := []struct {
@@ -750,6 +750,19 @@ func TestTarget_WriteRunToml(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
+		{
+			name:   "fail-with-nil-fname-field",
+			fields: fields{},
+			args: args{
+				mod: input.ModuleParams{
+					Order: []string{"topoaa"},
+					Topoaa: map[string]any{
+						"param_fname": nil,
+					},
+				},
+			},
+			wantErr: true,
+		},
 		{
 			name: "pass",
 			fields: fields{
@@ -762,7 +775,7 @@ func TestTarget_WriteRunToml(t *testing.T) {
 			},
 			args: args{
 				projectDir: "_some-workdir",
-				general: map[string]interface{}{
+				general: map[string]any{
 					"receptor":     "receptor.pdb",
 					"ligand":       "ligand.pdb",
 					"int":          10,
@@ -774,10 +787,10 @@ func TestTarget_WriteRunToml(t *testing.T) {
 				},
 				mod: input.ModuleParams{
 					Order: []string{"topoaa", "rigidbody", "caprieval", "flexref", "caprieval.2", "mdref", "caprieval.3"},
-					Topoaa: map[string]interface{}{
+					Topoaa: map[string]any{
 						"some-param": "some-value",
 					},
-					Rigidbody: map[string]interface{}{
+					Rigidbody: map[string]any{
 						"some-other-param":   10,
 						"some_fname":         "ambig_ti",
 						"another_fname":      "unambig",
@@ -785,21 +798,21 @@ func TestTarget_WriteRunToml(t *testing.T) {
 						"someother_fname":    "custom2",
 						"thereference_fname": "ref",
 					},
-					Caprieval: map[string]interface{}{},
-					Flexref: map[string]interface{}{
+					Caprieval: map[string]any{},
+					Flexref: map[string]any{
 						"some-other-param": 3.5,
 						"array-int":        []int{1, 2, 3},
 						"array-float":      []float64{1.1, 2.2, 3.3},
 						"array-string":     []string{"a", "b", "c"},
 						"array-bool":       []bool{true, false, true},
-						"array-interface":  []interface{}{1, 2.2, "three", true},
+						"array-interface":  []any{1, 2.2, "three", true},
 						"expandable_":      []int{1, 2, 3},
 					},
-					Caprieval_2: map[string]interface{}{},
-					Mdref: map[string]interface{}{
+					Caprieval_2: map[string]any{},
+					Mdref: map[string]any{
 						"some-other-param": false,
 					},
-					Caprieval_3: map[string]interface{}{},
+					Caprieval_3: map[string]any{},
 				},
 			},
 			want:    "_some-workdir/run.toml",
@@ -818,7 +831,7 @@ func TestTarget_WriteRunToml(t *testing.T) {
 			},
 			args: args{
 				projectDir: "_some-workdir",
-				general: map[string]interface{}{
+				general: map[string]any{
 					"receptor":     "receptor.pdb",
 					"ligand":       "ligand.pdb",
 					"shape":        "shape.pdb",
@@ -831,10 +844,10 @@ func TestTarget_WriteRunToml(t *testing.T) {
 				},
 				mod: input.ModuleParams{
 					Order: []string{"topoaa", "rigidbody"},
-					Topoaa: map[string]interface{}{
+					Topoaa: map[string]any{
 						"some-param": "some-value",
 					},
-					Rigidbody: map[string]interface{}{
+					Rigidbody: map[string]any{
 						"some-other-param":   10,
 						"some_fname":         "ambig_ti",
 						"another_fname":      "unambig",
@@ -859,7 +872,7 @@ func TestTarget_WriteRunToml(t *testing.T) {
 			},
 			args: args{
 				projectDir: "unexisting-directory",
-				general:    map[string]interface{}{},
+				general:    map[string]any{},
 				mod:        input.ModuleParams{},
 			},
 			want:    "",


### PR DESCRIPTION
# ===autogenerated===
This pull request refactors the type usage in the `WriteRunToml` function and related code to replace `interface{}` with `any`, improving code clarity and consistency with modern Go conventions. Additionally, it introduces a nil-check for module parameters to prevent runtime errors, and updates the associated tests to cover this new validation.

Type refactoring:

* Changed all occurrences of `map[string]interface{}` and `[]interface{}` to `map[string]any` and `[]any` in `dataset/dataset.go` and `dataset/dataset_test.go`, aligning with Go 1.18+ best practices. [[1]](diffhunk://#diff-21610a5c8c9eca523aa4d7f8019cfeaeb59daf2e90f6e42f4af483b52ac21926L218-R218) [[2]](diffhunk://#diff-21610a5c8c9eca523aa4d7f8019cfeaeb59daf2e90f6e42f4af483b52ac21926L319-R323) [[3]](diffhunk://#diff-f1e113bfec9e1b22949ad793e47bde879a5aa5d271f7010222d44514fc41d6b6L743-R743) [[4]](diffhunk://#diff-f1e113bfec9e1b22949ad793e47bde879a5aa5d271f7010222d44514fc41d6b6L765-R778) [[5]](diffhunk://#diff-f1e113bfec9e1b22949ad793e47bde879a5aa5d271f7010222d44514fc41d6b6L777-R815) [[6]](diffhunk://#diff-f1e113bfec9e1b22949ad793e47bde879a5aa5d271f7010222d44514fc41d6b6L821-R834) [[7]](diffhunk://#diff-f1e113bfec9e1b22949ad793e47bde879a5aa5d271f7010222d44514fc41d6b6L834-R850) [[8]](diffhunk://#diff-f1e113bfec9e1b22949ad793e47bde879a5aa5d271f7010222d44514fc41d6b6L862-R875)

Validation improvements:

* Added a nil-check for module parameter values in `WriteRunToml` to return an error if any parameter is empty (nil), improving robustness and error reporting.

Test coverage:

* Updated and expanded tests in `dataset/dataset_test.go` to use `any` instead of `interface{}` and added a new test case to verify error handling for nil parameter values.