### PR TITLE
fix repeated module support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "haddock-runner"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "haddock-runner"
-version = "3.1.0"
+version = "3.1.1"
 edition = "2024"
 authors = ["Rodrigo V. Honorato <r.vargashonorato@uu.nl>"]
 description = "Run large scale HADDOCK simulations using multiple input molecules in different scenarios"

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -150,6 +150,34 @@ The `workflow` section within each scenario defines the HADDOCK3 modules to exec
 
 Look in the [haddock repository](https://github.com/haddocking/haddock3) for information about modules/parameters for each module.
 
+### Repeated Modules
+
+To run the same HADDOCK3 module more than once in a workflow (e.g. two `caprieval` steps), append a `.digit` suffix to each occurrence. Suffixes must start at `.1` and be sequential with no gaps.
+
+```yaml
+scenarios:
+  - name: evaluate-before-and-after
+    workflow:
+      topoaa:
+        autohis: true
+      rigidbody:
+        sampling: 1000
+        ambig_fname: _ti.tbl
+      caprieval.1:
+        reference_fname: _ref.pdb
+      flexref:
+        ambig_fname: _ti.tbl
+      caprieval.2:
+        reference_fname: _ref.pdb
+```
+
+
+- All instances of a repeated module **must** carry a `.digit` suffix — mixing a bare name with a suffixed one (e.g. `caprieval` and `caprieval.1`) is an error.
+- Suffixes must be **sequential starting at `.1`**: `.1`, `.2`, `.3`, … Gaps (e.g. `.1`, `.3`) or a different starting point (e.g. `.2`, `.3`) are not allowed.
+- A module that appears only once does **not** need a suffix.
+
+> **Why `.digit` suffixes?** YAML does not allow duplicate keys in a mapping, so two plain `caprieval:` entries would be silently merged. The `.digit` convention gives each entry a unique key while haddock-runner strips the suffix when generating the haddock3 configuration file.
+
 ### Module Parameter Patterns
 
 Many parameters accept **filename patterns** instead of explicit paths. These patterns are matched against the files available for each target. The pattern matching uses regular expressions.
@@ -292,6 +320,11 @@ The configuration file is validated before execution. The following rules apply:
 4. **`input_list`**: Must not be an empty string, and the file must exist.
 5. **`max_concurrent`**: Must be greater than 0.
 6. **`ncores`**: Must be greater than 0.
+
+### Workflow Section
+
+1. **Repeated modules**: A bare module name (e.g. `caprieval`) must not coexist with a suffixed variant (e.g. `caprieval.1`) in the same workflow.
+2. **Suffix sequencing**: Suffixes for repeated modules must start at `.1` and be sequential with no gaps (`.1`, `.2`, `.3`, …).
 
 ### Local Execution
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -171,7 +171,6 @@ scenarios:
         reference_fname: _ref.pdb
 ```
 
-
 - All instances of a repeated module **must** carry a `.digit` suffix — mixing a bare name with a suffixed one (e.g. `caprieval` and `caprieval.1`) is an error.
 - Suffixes must be **sequential starting at `.1`**: `.1`, `.2`, `.3`, … Gaps (e.g. `.1`, `.3`) or a different starting point (e.g. `.2`, `.3`) are not allowed.
 - A module that appears only once does **not** need a suffix.

--- a/src/input.rs
+++ b/src/input.rs
@@ -8,8 +8,12 @@ use serde_yaml::Value;
 use std::{
     fs,
     path::{Path, PathBuf},
+    sync::LazyLock,
     thread,
 };
+
+pub(crate) static DIGIT_SUFFIX_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(.*?)\.(\d+)$").unwrap());
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
@@ -84,19 +88,17 @@ impl Input {
     /// Mixing a bare name with a suffixed variant (e.g. `caprieval` + `caprieval.1`)
     /// is rejected because haddock3 cannot reconcile the two forms.
     pub fn validate_workflows(&self) -> Result<()> {
-        let digit_suffix_re = Regex::new(r"^(.*?)\.(\d+)$").unwrap();
-
         for scenario in &self.scenarios {
             // Check for bare names coexisting with suffixed siblings
             for name in scenario.workflow.modules.keys() {
-                if digit_suffix_re.captures(name).is_none() {
+                if DIGIT_SUFFIX_RE.captures(name).is_none() {
                     let has_suffixed_sibling = scenario
                         .workflow
                         .modules
                         .keys()
                         .filter(|n| *n != name)
                         .any(|n| {
-                            digit_suffix_re
+                            DIGIT_SUFFIX_RE
                                 .captures(n)
                                 .map(|c| c.get(1).unwrap().as_str() == name.as_str())
                                 .unwrap_or(false)
@@ -115,7 +117,7 @@ impl Input {
             let mut suffix_map: std::collections::HashMap<String, Vec<u32>> =
                 std::collections::HashMap::new();
             for name in scenario.workflow.modules.keys() {
-                if let Some(caps) = digit_suffix_re.captures(name) {
+                if let Some(caps) = DIGIT_SUFFIX_RE.captures(name) {
                     let base = caps.get(1).unwrap().as_str().to_string();
                     let n: u32 = caps.get(2).unwrap().as_str().parse().unwrap();
                     suffix_map.entry(base).or_default().push(n);

--- a/src/input.rs
+++ b/src/input.rs
@@ -87,7 +87,7 @@ impl Input {
     /// `.digit` suffixes (e.g. `caprieval.1`, `caprieval.2`) starting at 1 with no gaps.
     /// Mixing a bare name with a suffixed variant (e.g. `caprieval` + `caprieval.1`)
     /// is rejected because haddock3 cannot reconcile the two forms.
-    pub fn validate_workflows(&self) -> Result<()> {
+    fn validate_workflows(&self) -> Result<()> {
         for scenario in &self.scenarios {
             // Check for bare names coexisting with suffixed siblings
             for name in scenario.workflow.modules.keys() {

--- a/src/input.rs
+++ b/src/input.rs
@@ -2,6 +2,7 @@ use crate::runner::slurm::validate_slurm;
 use crate::utils::validate_haddock3;
 use anyhow::{Context, Result, bail};
 use indexmap::IndexMap;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_yaml::Value;
 use std::{
@@ -69,8 +70,74 @@ impl Input {
         // Validate general fields
         self.validate_general()?;
 
+        // Validate workflow module naming
+        self.validate_workflows()?;
+
         // Validate haddock3
         validate_haddock3()?;
+
+        Ok(())
+    }
+
+    /// Validates that repeated modules in every scenario workflow consistently use
+    /// `.digit` suffixes (e.g. `caprieval.1`, `caprieval.2`) starting at 1 with no gaps.
+    /// Mixing a bare name with a suffixed variant (e.g. `caprieval` + `caprieval.1`)
+    /// is rejected because haddock3 cannot reconcile the two forms.
+    pub fn validate_workflows(&self) -> Result<()> {
+        let digit_suffix_re = Regex::new(r"^(.*?)\.(\d+)$").unwrap();
+
+        for scenario in &self.scenarios {
+            // Check for bare names coexisting with suffixed siblings
+            for name in scenario.workflow.modules.keys() {
+                if digit_suffix_re.captures(name).is_none() {
+                    let has_suffixed_sibling = scenario
+                        .workflow
+                        .modules
+                        .keys()
+                        .filter(|n| *n != name)
+                        .any(|n| {
+                            digit_suffix_re
+                                .captures(n)
+                                .map(|c| c.get(1).unwrap().as_str() == name.as_str())
+                                .unwrap_or(false)
+                        });
+                    if has_suffixed_sibling {
+                        bail!(
+                            "scenario '{}': module '{name}' mixes bare and .digit-suffixed names; \
+                            repeated modules must all use .digit suffixes (e.g. {name}.1, {name}.2)",
+                            scenario.name
+                        );
+                    }
+                }
+            }
+
+            // Check that suffixed modules are sequential starting at 1
+            let mut suffix_map: std::collections::HashMap<String, Vec<u32>> =
+                std::collections::HashMap::new();
+            for name in scenario.workflow.modules.keys() {
+                if let Some(caps) = digit_suffix_re.captures(name) {
+                    let base = caps.get(1).unwrap().as_str().to_string();
+                    let n: u32 = caps.get(2).unwrap().as_str().parse().unwrap();
+                    suffix_map.entry(base).or_default().push(n);
+                }
+            }
+            for (base, mut indices) in suffix_map {
+                indices.sort();
+                let expected: Vec<u32> = (1..=indices.len() as u32).collect();
+                if indices != expected {
+                    bail!(
+                        "scenario '{}': module '{base}' suffixes must be sequential starting at 1 \
+                        (e.g. {base}.1, {base}.2), got: {}",
+                        scenario.name,
+                        indices
+                            .iter()
+                            .map(|n| format!("{base}.{n}"))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    );
+                }
+            }
+        }
 
         Ok(())
     }
@@ -514,5 +581,90 @@ scenarios:
 
         let result: Result<Input, _> = serde_yaml::from_str(yaml);
         assert!(result.is_err());
+    }
+
+    fn make_input_with_workflow(modules: IndexMap<String, Value>) -> Input {
+        Input {
+            general: General {
+                mol_suffixes: vec!["_r".to_string(), "_l".to_string()],
+                input_list: "test.txt".to_string(),
+                work_dir: PathBuf::from("/tmp"),
+                max_concurrent: 1,
+                ncores: 1,
+                execution: Execution::Local,
+                partition: None,
+            },
+            scenarios: vec![Scenario {
+                name: "test".to_string(),
+                workflow: Workflow { modules },
+            }],
+        }
+    }
+
+    #[test]
+    fn test_validate_workflow_repeated_modules_with_digits_is_ok() {
+        let mut modules = IndexMap::new();
+        modules.insert("topoaa".to_string(), Value::Null);
+        modules.insert("caprieval.1".to_string(), Value::Null);
+        modules.insert("caprieval.2".to_string(), Value::Null);
+
+        let input = make_input_with_workflow(modules);
+        assert!(input.validate_workflows().is_ok());
+    }
+
+    #[test]
+    fn test_validate_workflow_mixed_bare_and_suffixed_is_error() {
+        let mut modules = IndexMap::new();
+        modules.insert("topoaa".to_string(), Value::Null);
+        modules.insert("caprieval".to_string(), Value::Null);
+        modules.insert("caprieval.1".to_string(), Value::Null);
+
+        let input = make_input_with_workflow(modules);
+        assert!(input.validate_workflows().is_err());
+    }
+
+    #[test]
+    fn test_validate_workflow_sequential_digits_three_is_ok() {
+        let mut modules = IndexMap::new();
+        modules.insert("topoaa".to_string(), Value::Null);
+        modules.insert("caprieval.1".to_string(), Value::Null);
+        modules.insert("caprieval.2".to_string(), Value::Null);
+        modules.insert("caprieval.3".to_string(), Value::Null);
+
+        let input = make_input_with_workflow(modules);
+        assert!(input.validate_workflows().is_ok());
+    }
+
+    #[test]
+    fn test_validate_workflow_not_starting_at_one_is_error() {
+        let mut modules = IndexMap::new();
+        modules.insert("topoaa".to_string(), Value::Null);
+        modules.insert("caprieval.2".to_string(), Value::Null);
+        modules.insert("caprieval.3".to_string(), Value::Null);
+
+        let input = make_input_with_workflow(modules);
+        assert!(input.validate_workflows().is_err());
+    }
+
+    #[test]
+    fn test_validate_workflow_gap_in_sequence_is_error() {
+        let mut modules = IndexMap::new();
+        modules.insert("topoaa".to_string(), Value::Null);
+        modules.insert("caprieval.1".to_string(), Value::Null);
+        modules.insert("caprieval.3".to_string(), Value::Null);
+
+        let input = make_input_with_workflow(modules);
+        assert!(input.validate_workflows().is_err());
+    }
+
+    #[test]
+    fn test_validate_workflow_zero_based_is_error() {
+        let mut modules = IndexMap::new();
+        modules.insert("topoaa".to_string(), Value::Null);
+        modules.insert("caprieval.0".to_string(), Value::Null);
+        modules.insert("caprieval.1".to_string(), Value::Null);
+
+        let input = make_input_with_workflow(modules);
+        assert!(input.validate_workflows().is_err());
     }
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 use itertools::Itertools;
 
-use crate::input::{Execution, General};
+use crate::input::{Execution, General, DIGIT_SUFFIX_RE};
 use crate::runner::local;
 use crate::runner::status::Status;
 use crate::{
@@ -309,8 +309,6 @@ impl Job {
     fn generate_run_toml(&self) -> anyhow::Result<String> {
         let mut toml_content = String::new();
         let all_files = self.get_all_target_files();
-        let digit_suffix_re = Regex::new(r"\.\d+$").unwrap();
-
         // Add general HADDOCK3 configuration
         toml_content.push_str("run_dir = \"run1\"\nmode = \"local\"\n");
 
@@ -330,7 +328,7 @@ impl Job {
         for (module_name, module_params) in &self.scenario.workflow.modules {
             // Modules with a .digit suffix are quoted so haddock3 treats the dot as a literal
             // character rather than a TOML nested-table separator.
-            let header = if digit_suffix_re.is_match(module_name) {
+            let header = if DIGIT_SUFFIX_RE.is_match(module_name) {
                 format!("[\"{module_name}\"]\n")
             } else {
                 format!("[{module_name}]\n")

--- a/src/job.rs
+++ b/src/job.rs
@@ -309,6 +309,7 @@ impl Job {
     fn generate_run_toml(&self) -> anyhow::Result<String> {
         let mut toml_content = String::new();
         let all_files = self.get_all_target_files();
+        let digit_suffix_re = Regex::new(r"\.\d+$").unwrap();
 
         // Add general HADDOCK3 configuration
         toml_content.push_str("run_dir = \"run1\"\nmode = \"local\"\n");
@@ -327,7 +328,14 @@ impl Job {
 
         // Add workflow modules from scenario
         for (module_name, module_params) in &self.scenario.workflow.modules {
-            toml_content.push_str(&format!("[{}]\n", module_name));
+            // Modules with a .digit suffix are quoted so haddock3 treats the dot as a literal
+            // character rather than a TOML nested-table separator.
+            let header = if digit_suffix_re.is_match(module_name) {
+                format!("[\"{module_name}\"]\n")
+            } else {
+                format!("[{module_name}]\n")
+            };
+            toml_content.push_str(&header);
 
             if let Some(params) = module_params.as_mapping() {
                 for (key, value) in params.iter() {
@@ -450,6 +458,7 @@ mod tests {
     use crate::input::{Execution, General, Scenario, Workflow};
     use crate::runner::status::Status;
     use indexmap::IndexMap;
+    use serde_yaml::Value;
     use std::path::PathBuf;
     use tempfile::tempdir;
 
@@ -798,5 +807,99 @@ mod tests {
 #SBATCH --cpus-per-task=4\n\
 #SBATCH --partition=gpu\n";
         assert_eq!(header, expected);
+    }
+
+    fn make_job_with_modules(modules: IndexMap<String, Value>) -> Job {
+        Job {
+            name: "test".to_string(),
+            status: Status::Unknown,
+            wd: PathBuf::from("/tmp"),
+            target: Target {
+                id: "test".to_string(),
+                molecules: vec![PathBuf::from("mol.pdb")],
+                restraints: vec![],
+                toppar: vec![],
+                misc: vec![],
+                shape: None,
+                size: 0,
+            },
+            scenario: Scenario {
+                name: "test".to_string(),
+                workflow: Workflow { modules },
+            },
+            general: General {
+                mol_suffixes: vec!["_r".to_string(), "_l".to_string()],
+                input_list: "test.txt".to_string(),
+                work_dir: PathBuf::from("/tmp"),
+                max_concurrent: 1,
+                ncores: 1,
+                execution: Execution::Local,
+                partition: None,
+            },
+        }
+    }
+
+    #[test]
+    fn test_generate_run_toml_repeated_modules() {
+        let mut modules = IndexMap::new();
+        modules.insert("topoaa".to_string(), Value::Null);
+        modules.insert("caprieval.1".to_string(), Value::Null);
+        modules.insert("caprieval.2".to_string(), Value::Null);
+
+        let job = make_job_with_modules(modules);
+        let toml = job.generate_run_toml().unwrap();
+
+        assert!(
+            toml.contains("[\"caprieval.1\"]"),
+            "expected [\"caprieval.1\"] but got:\n{toml}"
+        );
+        assert!(
+            toml.contains("[\"caprieval.2\"]"),
+            "expected [\"caprieval.2\"] but got:\n{toml}"
+        );
+        assert!(
+            !toml.contains("[caprieval.1]"),
+            "unquoted [caprieval.1] should not appear"
+        );
+    }
+
+    #[test]
+    fn test_generate_run_toml_single_suffixed_module() {
+        // A module with a .digit suffix appearing alone should still be quoted
+        let mut modules = IndexMap::new();
+        modules.insert("topoaa".to_string(), Value::Null);
+        modules.insert("emscoring.1".to_string(), Value::Null);
+
+        let job = make_job_with_modules(modules);
+        let toml = job.generate_run_toml().unwrap();
+
+        assert!(
+            toml.contains("[\"emscoring.1\"]"),
+            "expected [\"emscoring.1\"] but got:\n{toml}"
+        );
+        assert!(
+            !toml.contains("[emscoring.1]"),
+            "unquoted [emscoring.1] should not appear"
+        );
+    }
+
+    #[test]
+    fn test_generate_run_toml_plain_modules_unaffected() {
+        // Modules without a .digit suffix must keep plain [module] headers
+        let mut modules = IndexMap::new();
+        modules.insert("topoaa".to_string(), Value::Null);
+        modules.insert("caprieval".to_string(), Value::Null);
+
+        let job = make_job_with_modules(modules);
+        let toml = job.generate_run_toml().unwrap();
+
+        assert!(
+            toml.contains("[topoaa]"),
+            "expected [topoaa] but got:\n{toml}"
+        );
+        assert!(
+            toml.contains("[caprieval]"),
+            "expected [caprieval] but got:\n{toml}"
+        );
     }
 }


### PR DESCRIPTION
Fix #190 by properly handling repeated modules.

Added a validator to check that repeated modules contain digits, and when writing this repeated modules to the `.toml` they need to be quoted => `["module.1"]` 